### PR TITLE
find the best icon by image dimension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.9.1",
     "cheerio": "^0.20.0",
     "file-type": "^3.8.0",
+    "image-size": "^0.5.0",
     "source-map-support": "^0.4.0"
   },
   "devDependencies": {

--- a/src/modules/download/downloadIcon.js
+++ b/src/modules/download/downloadIcon.js
@@ -1,6 +1,8 @@
 const axios = require('axios');
 const url = require('url');
 const fileType = require('file-type');
+const imageSize = require('image-size');
+
 
 function getExtension(downloadUrl) {
     return downloadUrl.match(/\.(png|jpg|ico)/)[0];
@@ -41,7 +43,15 @@ function downloadIcon(iconUrl) {
         // add `.` to ext
         fileDetails.ext = `.${fileDetails.ext}`;
 
+        var dimension;
+        try {
+            dimension = imageSize(iconData);
+        } catch (e) {
+            dimension = { width: 0, height: 0 };
+        }
+
         return Object.assign({
+        	dimension: dimension,
             source: iconUrl,
             name: getSiteDomain(iconUrl),
             data: iconData,

--- a/src/modules/findBestIcon.js
+++ b/src/modules/findBestIcon.js
@@ -1,10 +1,31 @@
+function checkSquareDimension(dimension) {
+    if (dimension == null || dimension.width <= 0 || dimension.height <= 0) {
+        return false;
+    }
+
+    return dimension.width === dimension.height;
+}
+
+function compareByDimension(a, b) {
+	var ra = checkSquareDimension(a.dimension);
+    var rb = checkSquareDimension(b.dimension);
+
+    if (rb == true && ra == false) {
+    	return 1;
+    } else if (rb == false && ra == true) {
+    	return -1;
+    }
+
+   	return b.dimension.width - a.dimension.width;
+}
+
+function sortIconsByDimension(icons) {
+    return icons.sort(compareByDimension);
+}
+
 function sortIconsBySize(icons) {
-    return icons.sort((a, b) => {
-        if (a.size < b.size) {
-            return 1;
-        } else {
-            return -1;
-        }
+    return icons.sort(function (a, b) {
+        return b.size - a.size;
     });
 }
 
@@ -14,7 +35,9 @@ function sortIconsBySize(icons) {
  * @param [ext]
  */
 function findBestIcon(icons, ext) {
-    const sorted = sortIconsBySize(icons);
+    var sortingFunc = ext == '.ico' ? sortIconsBySize : sortIconsByDimension; //image-size doesn't support .ico.
+	var sorted = sortingFunc(icons);
+
     if (ext) {
         for (let icon of sorted) {
             if (icon.ext === ext) {


### PR DESCRIPTION
- Add image dimension to icon informations.
- Modified to only choose icon which are two square image If download icon as png.
- Compared with image dimension not image size when sort icons for priviledge. (If it compared by image data size the '.ico' extension has chosen in everytime even if the png image has better quality)