### PR TITLE
Fix downloadIcon broken since recent axios bump

### DIFF
--- a/src/modules/download/downloadIcon.js
+++ b/src/modules/download/downloadIcon.js
@@ -20,7 +20,7 @@ function downloadIcon(iconUrl) {
                 resolve(response.data);
             })
             .catch(function(error) {
-                if (error.response.status === 404) {
+                if (error.response && error.response.status === 404) {
                     resolve();
                     return;
                 }

--- a/src/modules/download/downloadIcon.js
+++ b/src/modules/download/downloadIcon.js
@@ -20,7 +20,7 @@ function downloadIcon(iconUrl) {
                 resolve(response.data);
             })
             .catch(function(error) {
-                if (error.status === 404) {
+                if (error.response.status === 404) {
                     resolve();
                     return;
                 }


### PR DESCRIPTION
Turns out, there were a lot of breaking changes in the
0.9 -> 0.21 bump:
https://github.com/axios/axios/blob/master/CHANGELOG.md

`error.status` must have been cleaned up at some point,
it's no longer here, I think since 0.12.x -> 0.13.0,
https://github.com/axios/axios/blob/master/UPGRADE_GUIDE.md#error-handling
We should now look at `error.response.status`,
as documented in https://github.com/axios/axios#handling-errors

Tested and working locally in Nativefier.